### PR TITLE
Fix GitHub spelling

### DIFF
--- a/app/routes/about.mdx
+++ b/app/routes/about.mdx
@@ -4,7 +4,7 @@ date: '2024-11-05'
 type: 'page'
 ---
 
-I am a software engineer at [Indeed](http://indeed.com) in Austin, TX. I'm focused on AI Platforms.  Also see Github: [mihalik](https://github.com/mihalik)
+I am a software engineer at [Indeed](http://indeed.com) in Austin, TX. I'm focused on AI Platforms.  Also see GitHub: [mihalik](https://github.com/mihalik)
 
 - 💻 Programming
 - 🤖 AI/ML


### PR DESCRIPTION
## Summary
- fix `Github` text in `about` page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f4dca10a0832aa2da8541d3bdd839